### PR TITLE
chore: Spring Boot 4.0 프로젝트 초기화 + 의존성 설정 (#2)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,15 @@ repositories {
 
 ext {
 	set('snippetsDir', file("build/generated-snippets"))
+	set('queryDslVersion', '5.1.0')
+}
+
+sourceSets {
+	main {
+		java {
+			srcDir layout.buildDirectory.dir('generated/sources/annotationProcessor/java/main')
+		}
+	}
 }
 
 dependencies {
@@ -31,6 +40,11 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
+	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta"
+	annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"
+	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2'
 	runtimeOnly 'org.postgresql:postgresql'
 	testImplementation 'org.springframework.boot:spring-boot-starter-actuator-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-batch-test'

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,17 @@
 spring:
   application:
     name: carrot.settle
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        default_batch_fetch_size: 100
+  data:
+    redis:
+      timeout: 2000ms
+  batch:
+    jdbc:
+      initialize-schema: always


### PR DESCRIPTION
## 📝 변경사항

Spring Boot 4.0.x + Java 21 기반 프로젝트 초기화에 필요한 의존성 및 설정을 추가한다.

### 주요 변경사항
- QueryDSL 5.1.0 의존성 + APT 설정 추가
- springdoc-openapi 3.0.2 추가 (Spring Boot 4.x 호환 버전)
- application.yaml에 JPA, Redis, Spring Batch 설정 추가

### 상세 설명
- `springdoc-openapi-starter-webmvc-ui:2.x`는 Spring Boot 4.x(Spring Framework 7.x)와 호환되지 않아 3.0.2로 변경
- QueryDSL sourceSets에 APT 생성 경로(`generated/sources/annotationProcessor/java/main`) 추가
- `spring.jpa.hibernate.ddl-auto: update`, Redis timeout, Batch schema 초기화 설정 포함

## 🔍 변경된 파일

```
build.gradle                        | 14 ++++++++++++++
src/main/resources/application.yaml | 14 ++++++++++++++
2 files changed, 28 insertions(+)
```

## 🧪 테스트
- [x] `./gradlew bootRun` 정상 기동 확인
- [x] `/swagger-ui.html` 접속 확인
- [x] PostgreSQL 연결 확인

### 테스트 방법
```bash
./gradlew bootRun
# http://localhost:8080/swagger-ui.html 접속 확인
```

## ✅ 체크리스트

- [x] Conventional Commits 형식 준수
- [x] 민감 정보 미포함 확인
- [x] 관련 이슈 체크리스트 업데이트 완료

## 📚 관련 이슈

Closes #2