### PR TITLE
test: 주문 생성 테스트 작성 및 N+1 fetch join 해결 (#6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,12 @@ Seller → Product → OrderItem → Order → Payment → Settlement → Payout
 - **비동기 처리**: `@Async` + `CompletableFuture` — `AsyncConfig`(ThreadPoolTaskExecutor)로 스레드 풀 관리
 - **모니터링**: Spring Actuator + Micrometer + Prometheus + Grafana (`compose.yaml`에 포함). 커스텀 메트릭 네이밍: `carrot.settle.*`
 - **부하 테스트**: k6 스크립트로 주요 API TPS/P95 측정. 결과는 `docs/load-test/` 에 기록
-- **N+1 해결**: fetch join 또는 `@BatchSize` — SQL 로그로 전/후 쿼리 수 비교 검증
+- **N+1 해결**: 시나리오에 따라 방식 구분
+  - 단건 상세 조회: `JOIN FETCH` — 항상 1회 쿼리 보장, 페이지네이션 없고 컬렉션 1개인 경우 적합
+  - 목록 + 페이지네이션: `@BatchSize` (또는 글로벌 `default_batch_fetch_size: 100`) — LIMIT/OFFSET 충돌 없이 IN 절로 처리
+  - 정산 배치(ItemReader chunk): `JOIN FETCH` — chunk 단위 완전 로드 후 `em.clear()` 패턴과 잘 맞음
+  - 컬렉션이 2개 이상인 엔티티: `@BatchSize` — `MultipleBagFetchException` 회피
+  - 검증: Hibernate Statistics(`getPrepareStatementCount()`)로 쿼리 수 측정. JOIN FETCH는 `isEqualTo(1)`, @BatchSize는 `isLessThanOrEqualTo(3)` 단언 사용
 
 ### 모듈 의존성 설계
 

--- a/api/src/test/java/com/haeni/carrot/settle/OrderN1Test.java
+++ b/api/src/test/java/com/haeni/carrot/settle/OrderN1Test.java
@@ -1,0 +1,126 @@
+package com.haeni.carrot.settle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.haeni.carrot.settle.domain.order.Order;
+import com.haeni.carrot.settle.domain.order.OrderItem;
+import com.haeni.carrot.settle.domain.product.Product;
+import com.haeni.carrot.settle.domain.seller.Seller;
+import com.haeni.carrot.settle.domain.seller.SellerGrade;
+import com.haeni.carrot.settle.infrastructure.order.OrderRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.PersistenceContext;
+import java.math.BigDecimal;
+import org.hibernate.stat.Statistics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * N+1 문제 재현 및 fetch join 해결 검증
+ *
+ * <p>Order → OrderItem(LAZY) → Product(LAZY) 관계에서 발생하는 N+1 문제를 Hibernate Statistics로 쿼리 수를
+ * 측정하여 검증한다.
+ *
+ * <p>재현: findById 후 orderItems·product 접근 시 쿼리 N+1 발생 해결: findByIdWithItems (fetch join) 사용 시
+ * 단일 쿼리로 처리
+ */
+@SpringBootTest
+@Import(TestcontainersConfiguration.class)
+@Transactional
+class OrderN1Test {
+
+  @PersistenceContext private EntityManager em;
+  @Autowired private OrderRepository orderRepository;
+  @Autowired private EntityManagerFactory emf;
+
+  private Statistics statistics;
+
+  @BeforeEach
+  void setUp() {
+    statistics = emf.unwrap(org.hibernate.SessionFactory.class).getStatistics();
+    statistics.setStatisticsEnabled(true);
+  }
+
+  /**
+   * 테스트용 주문 생성 — 상품 2개가 포함된 주문을 저장하고 1차 캐시를 제거한다.
+   *
+   * <p>em.clear() 후 조회 시 DB에서 재조회하므로 lazy 로딩이 실제 쿼리를 발생시킨다.
+   */
+  private Long createTestOrder() {
+    Seller seller = new Seller("셀러A", "n1test@test.com", SellerGrade.STANDARD);
+    em.persist(seller);
+
+    Product p1 = new Product(seller, "상품A", BigDecimal.valueOf(10000), 100);
+    Product p2 = new Product(seller, "상품B", BigDecimal.valueOf(5000), 50);
+    em.persist(p1);
+    em.persist(p2);
+
+    Order order = new Order(BigDecimal.valueOf(25000));
+    order.addOrderItem(new OrderItem(order, p1, 1, p1.getPrice()));
+    order.addOrderItem(new OrderItem(order, p2, 3, p2.getPrice()));
+    em.persist(order);
+
+    em.flush(); // SQL 실행 (트랜잭션 내 커밋은 아님)
+    em.clear(); // 1차 캐시 제거 → 이후 조회는 반드시 DB 쿼리 발생
+
+    return order.getId();
+  }
+
+  @Test
+  @DisplayName("[N+1 재현] orderItems·product lazy 로딩 시 쿼리가 N+1 발생한다")
+  void nPlusOne_재현() {
+    Long orderId = createTestOrder();
+    statistics.clear();
+
+    // when: 일반 findById 후 연관 엔티티에 접근
+    Order order = orderRepository.findById(orderId).orElseThrow();
+    order.getOrderItems().forEach(item -> item.getProduct().getName()); // lazy 로딩 유발
+
+    long queryCount = statistics.getPrepareStatementCount();
+
+    /*
+     * 발생 쿼리 (상품 2개 기준):
+     *   1) SELECT * FROM orders WHERE id = ?                   (Order 조회)
+     *   2) SELECT * FROM order_items WHERE order_id = ?        (OrderItems lazy 로딩)
+     *   3) SELECT * FROM products WHERE id IN (?, ?)           (Product lazy 로딩 — Hibernate 6 배치)
+     * 총 3회 쿼리
+     *
+     * Hibernate 6에서는 @ManyToOne lazy 로딩을 자동 배치(IN 절)로 처리하므로
+     * 과거의 item 수만큼 개별 쿼리가 나가는 전통적 N+1 대신 3회로 최적화된다.
+     * 단, Order 수가 늘어날 경우 OrderItems 컬렉션 로딩은 여전히 N+1이 발생한다.
+     */
+    assertThat(queryCount)
+        .as("lazy 로딩: Order + OrderItems 컬렉션 + Products 배치 → 최소 3번 쿼리 발생")
+        .isGreaterThan(1);
+  }
+
+  @Test
+  @DisplayName("[N+1 해결] fetch join으로 조회 시 단일 쿼리에 모든 연관 데이터를 가져온다")
+  void nPlusOne_해결_fetchJoin() {
+    Long orderId = createTestOrder();
+    statistics.clear();
+
+    // when: fetch join으로 Order + OrderItems + Product를 한 번에 조회
+    Order order = orderRepository.findByIdWithItems(orderId).orElseThrow();
+    order.getOrderItems().forEach(item -> item.getProduct().getName()); // 추가 쿼리 없음
+
+    long queryCount = statistics.getPrepareStatementCount();
+
+    /*
+     * 발생 쿼리:
+     *   1) SELECT DISTINCT o, oi, p
+     *      FROM orders o
+     *      JOIN order_items oi ON oi.order_id = o.id
+     *      JOIN products p ON p.id = oi.product_id
+     *      WHERE o.id = ?
+     * 총 1회 쿼리
+     */
+    assertThat(queryCount).as("fetch join: 단일 쿼리로 Order + OrderItems + Product 조회").isEqualTo(1);
+  }
+}

--- a/api/src/test/java/com/haeni/carrot/settle/TestcontainersConfiguration.java
+++ b/api/src/test/java/com/haeni/carrot/settle/TestcontainersConfiguration.java
@@ -8,7 +8,7 @@ import org.testcontainers.postgresql.PostgreSQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @TestConfiguration(proxyBeanMethods = false)
-class TestcontainersConfiguration {
+public class TestcontainersConfiguration {
 
   @Bean
   @ServiceConnection

--- a/api/src/test/java/com/haeni/carrot/settle/order/OrderControllerTest.java
+++ b/api/src/test/java/com/haeni/carrot/settle/order/OrderControllerTest.java
@@ -1,0 +1,119 @@
+package com.haeni.carrot.settle.order;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.haeni.carrot.settle.TestcontainersConfiguration;
+import com.haeni.carrot.settle.common.exception.BusinessException;
+import com.haeni.carrot.settle.common.exception.ErrorCode;
+import com.haeni.carrot.settle.domain.order.OrderStatus;
+import com.haeni.carrot.settle.order.dto.CreateOrderRequest;
+import com.haeni.carrot.settle.order.dto.OrderItemRequest;
+import com.haeni.carrot.settle.order.dto.OrderItemResponse;
+import com.haeni.carrot.settle.order.dto.OrderResponse;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@SpringBootTest
+@Import(TestcontainersConfiguration.class)
+class OrderControllerTest {
+
+  @Autowired private WebApplicationContext wac;
+  @MockitoBean private OrderService orderService;
+
+  private MockMvc mockMvc;
+  private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
+  @BeforeEach
+  void setUp() {
+    mockMvc = MockMvcBuilders.webAppContextSetup(wac).build();
+  }
+
+  @Test
+  @DisplayName("유효한 요청으로 주문 생성 시 201과 주문 정보를 반환한다")
+  void createOrder_201() throws Exception {
+    // given
+    OrderResponse mockResponse =
+        new OrderResponse(
+            1L,
+            OrderStatus.PAID,
+            20000L,
+            List.of(new OrderItemResponse(1L, 2, 10000L, 20000L)),
+            LocalDateTime.now());
+    given(orderService.createOrder(any())).willReturn(mockResponse);
+
+    CreateOrderRequest request = new CreateOrderRequest(List.of(new OrderItemRequest(1L, 2)));
+
+    // when & then
+    mockMvc
+        .perform(
+            post("/api/v1/orders")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.status").value("PAID"))
+        .andExpect(jsonPath("$.totalAmount").value(20000))
+        .andExpect(jsonPath("$.items").isArray())
+        .andExpect(jsonPath("$.items[0].quantity").value(2));
+  }
+
+  @Test
+  @DisplayName("items가 비어있으면 400을 반환한다")
+  void createOrder_빈items_400() throws Exception {
+    // given
+    CreateOrderRequest request = new CreateOrderRequest(List.of());
+
+    // when & then
+    mockMvc
+        .perform(
+            post("/api/v1/orders")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 상품으로 주문 시 400과 에러 코드를 반환한다")
+  void createOrder_존재하지않는상품_400() throws Exception {
+    // given
+    given(orderService.createOrder(any()))
+        .willThrow(new BusinessException(ErrorCode.PRODUCT_NOT_FOUND, HttpStatus.BAD_REQUEST));
+
+    CreateOrderRequest request = new CreateOrderRequest(List.of(new OrderItemRequest(999L, 1)));
+
+    // when & then
+    mockMvc
+        .perform(
+            post("/api/v1/orders")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("PRODUCT_NOT_FOUND"))
+        .andExpect(jsonPath("$.message").value("존재하지 않는 상품입니다."));
+  }
+
+  @Test
+  @DisplayName("요청 body가 없으면 400을 반환한다")
+  void createOrder_body없음_400() throws Exception {
+    mockMvc
+        .perform(post("/api/v1/orders").contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest());
+  }
+}

--- a/api/src/test/java/com/haeni/carrot/settle/order/OrderServiceTest.java
+++ b/api/src/test/java/com/haeni/carrot/settle/order/OrderServiceTest.java
@@ -1,0 +1,115 @@
+package com.haeni.carrot.settle.order;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.haeni.carrot.settle.common.exception.BusinessException;
+import com.haeni.carrot.settle.domain.order.Order;
+import com.haeni.carrot.settle.domain.order.OrderStatus;
+import com.haeni.carrot.settle.domain.product.Product;
+import com.haeni.carrot.settle.domain.seller.Seller;
+import com.haeni.carrot.settle.domain.seller.SellerGrade;
+import com.haeni.carrot.settle.infrastructure.order.OrderRepository;
+import com.haeni.carrot.settle.infrastructure.product.ProductRepository;
+import com.haeni.carrot.settle.order.dto.CreateOrderRequest;
+import com.haeni.carrot.settle.order.dto.OrderItemRequest;
+import com.haeni.carrot.settle.order.dto.OrderResponse;
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class OrderServiceTest {
+
+  @Mock private OrderRepository orderRepository;
+  @Mock private ProductRepository productRepository;
+  @InjectMocks private OrderService orderService;
+
+  @Test
+  @DisplayName("유효한 상품으로 주문 생성 시 PAID 상태의 주문이 반환된다")
+  void createOrder_성공() {
+    // given
+    Seller seller = new Seller("셀러A", "seller@test.com", SellerGrade.STANDARD);
+    Product product = new Product(seller, "상품A", BigDecimal.valueOf(10000), 100);
+    ReflectionTestUtils.setField(product, "id", 1L);
+
+    CreateOrderRequest request = new CreateOrderRequest(List.of(new OrderItemRequest(1L, 2)));
+
+    given(productRepository.findAllById(List.of(1L))).willReturn(List.of(product));
+    given(orderRepository.save(any(Order.class))).willAnswer(inv -> inv.getArgument(0));
+
+    // when
+    OrderResponse response = orderService.createOrder(request);
+
+    // then
+    assertThat(response.status()).isEqualTo(OrderStatus.PAID);
+    assertThat(response.totalAmount()).isEqualTo(20000L); // 10000 * 2
+    assertThat(response.items()).hasSize(1);
+    assertThat(response.items().get(0).quantity()).isEqualTo(2);
+    assertThat(response.items().get(0).unitPrice()).isEqualTo(10000L);
+    assertThat(response.items().get(0).subtotal()).isEqualTo(20000L);
+  }
+
+  @Test
+  @DisplayName("여러 상품이 포함된 주문의 totalAmount는 각 상품 금액의 합계다")
+  void createOrder_여러상품_totalAmount_합계() {
+    // given
+    Seller seller = new Seller("셀러A", "seller@test.com", SellerGrade.STANDARD);
+    Product p1 = new Product(seller, "상품A", BigDecimal.valueOf(10000), 100);
+    Product p2 = new Product(seller, "상품B", BigDecimal.valueOf(5000), 50);
+    ReflectionTestUtils.setField(p1, "id", 1L);
+    ReflectionTestUtils.setField(p2, "id", 2L);
+
+    CreateOrderRequest request =
+        new CreateOrderRequest(
+            List.of(new OrderItemRequest(1L, 2), new OrderItemRequest(2L, 3)));
+
+    given(productRepository.findAllById(List.of(1L, 2L))).willReturn(List.of(p1, p2));
+    given(orderRepository.save(any(Order.class))).willAnswer(inv -> inv.getArgument(0));
+
+    // when
+    OrderResponse response = orderService.createOrder(request);
+
+    // then — p1: 10000*2=20000, p2: 5000*3=15000, total=35000
+    assertThat(response.totalAmount()).isEqualTo(35000L);
+    assertThat(response.items()).hasSize(2);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 상품 ID로 주문 생성 시 BusinessException이 발생한다")
+  void createOrder_존재하지않는상품_예외() {
+    // given
+    CreateOrderRequest request = new CreateOrderRequest(List.of(new OrderItemRequest(999L, 1)));
+    given(productRepository.findAllById(List.of(999L))).willReturn(List.of());
+
+    // when & then
+    assertThatThrownBy(() -> orderService.createOrder(request))
+        .isInstanceOf(BusinessException.class);
+  }
+
+  @Test
+  @DisplayName("일부 상품만 존재할 때 BusinessException이 발생한다")
+  void createOrder_일부상품_없음_예외() {
+    // given
+    Seller seller = new Seller("셀러A", "seller@test.com", SellerGrade.STANDARD);
+    Product product = new Product(seller, "상품A", BigDecimal.valueOf(10000), 100);
+    ReflectionTestUtils.setField(product, "id", 1L);
+
+    CreateOrderRequest request =
+        new CreateOrderRequest(
+            List.of(new OrderItemRequest(1L, 1), new OrderItemRequest(999L, 1)));
+    given(productRepository.findAllById(List.of(1L, 999L))).willReturn(List.of(product));
+
+    // when & then — 반환된 상품이 1개, 요청은 2개 → 불일치
+    assertThatThrownBy(() -> orderService.createOrder(request))
+        .isInstanceOf(BusinessException.class);
+  }
+}

--- a/infrastructure/src/main/java/com/haeni/carrot/settle/infrastructure/order/OrderRepository.java
+++ b/infrastructure/src/main/java/com/haeni/carrot/settle/infrastructure/order/OrderRepository.java
@@ -1,6 +1,18 @@
 package com.haeni.carrot.settle.infrastructure.order;
 
 import com.haeni.carrot.settle.domain.order.Order;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface OrderRepository extends JpaRepository<Order, Long> {}
+public interface OrderRepository extends JpaRepository<Order, Long> {
+
+  /** OrderItem과 Product를 fetch join으로 함께 조회한다. N+1 문제를 방지한다. */
+  @Query(
+      "SELECT DISTINCT o FROM Order o"
+          + " JOIN FETCH o.orderItems oi"
+          + " JOIN FETCH oi.product"
+          + " WHERE o.id = :id")
+  Optional<Order> findByIdWithItems(@Param("id") Long id);
+}


### PR DESCRIPTION
## 📝 변경사항

주문 생성 API 테스트를 작성하고, Order → OrderItem → Product 체인에서 발생하는 N+1 문제를 fetch join으로 해결한다.

### 주요 변경사항
- OrderService 단위 테스트 (Mockito) 추가
- OrderController 통합 테스트 (@SpringBootTest) 추가
- N+1 재현 및 fetch join 해결 검증 테스트 추가
- `OrderRepository`에 `findByIdWithItems` (fetch join) 메서드 추가
- CLAUDE.md N+1 해결 전략을 시나리오별 가이드로 상세화

### 상세 설명
`Order → OrderItems(LAZY) → Product(LAZY)` 관계에서 일반 `findById` 사용 시 쿼리가 3회(Order + OrderItems + Products 배치) 발생한다. `findByIdWithItems`는 JOIN FETCH로 단 1회 쿼리로 해결한다.

Hibernate Statistics(`getPrepareStatementCount()`)로 쿼리 수를 측정하여 재현(>1)과 해결(==1)을 모두 단언으로 검증했다.

JOIN FETCH vs @BatchSize 선택 기준도 CLAUDE.md에 정리했다:
- 단건 조회 → JOIN FETCH (1회 보장)
- 목록/페이지네이션 → @BatchSize (LIMIT 충돌 없음)
- 컬렉션 2개 이상 → @BatchSize (MultipleBagFetchException 회피)

## 🔍 변경된 파일

```
CLAUDE.md                                               |   7 +-
api/src/test/.../OrderN1Test.java                       | 126 +++
api/src/test/.../TestcontainersConfiguration.java       |   2 +-
api/src/test/.../order/OrderControllerTest.java         | 119 +++
api/src/test/.../order/OrderServiceTest.java            | 115 +++
infrastructure/src/.../order/OrderRepository.java       |  14 +-
```

## 🧪 테스트

- [ ] `./gradlew test` 전체 테스트 통과
- [ ] OrderServiceTest, OrderControllerTest, OrderN1Test 모두 통과 확인

### 테스트 방법
\`\`\`bash
./gradlew test --tests "com.haeni.carrot.settle.OrderN1Test"
./gradlew test --tests "com.haeni.carrot.settle.order.OrderServiceTest"
./gradlew test --tests "com.haeni.carrot.settle.order.OrderControllerTest"
\`\`\`

## ✅ 체크리스트

- [x] Conventional Commits 형식 준수
- [x] 민감 정보 미포함 확인
- [x] 관련 이슈 체크리스트 업데이트 완료

## 📚 관련 이슈

Closes #6