### PR TITLE
feat: @Scheduled 자동 구매 확정 + 환불 API (#8)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,10 +52,11 @@ Seller → Product → OrderItem → Order → Payment → Settlement → Payout
 |--------|----------|------|
 | `POST` | `/api/v1/orders` | 주문 생성 (생성 즉시 PAID 상태) |
 | `PATCH` | `/api/v1/orders/{id}/confirm` | 수동 구매 확정 |
+| `PATCH` | `/api/v1/orders/{id}/refund` | 환불 처리 (PAID → REFUNDED, 정산 대상 제외) |
 | `GET` | `/api/v1/settlements` | 정산 내역 조회 (sellerId, 기간, status 필터 + 페이징) |
 | `POST` | `/api/v1/settlements/calculate` | 정산 배치 수동 트리거 |
 
-구매 확정은 매일 새벽 2시 `@Scheduled` 자동 실행도 병행한다.
+구매 확정은 매일 새벽 2시 `@Scheduled` 자동 실행도 병행한다. 자동 확정 스케줄러는 `OrderScheduler` 빈으로 분리 — `orderService.confirmOrder(id)` 호출 시 `@Transactional` 프록시 정상 동작 보장 (self-invocation 회피).
 
 ### 기술 선택 포인트
 

--- a/api/src/main/java/com/haeni/carrot/settle/order/OrderController.java
+++ b/api/src/main/java/com/haeni/carrot/settle/order/OrderController.java
@@ -58,4 +58,21 @@ public class OrderController {
   public ResponseEntity<OrderResponse> confirmOrder(@PathVariable Long id) {
     return ResponseEntity.ok(OrderResponse.from(orderService.confirmOrder(id)));
   }
+
+  @PatchMapping("/{id}/refund")
+  @Operation(summary = "환불 처리", description = "PAID 상태의 주문을 REFUNDED로 전환합니다. 정산 대상에서 제외됩니다.")
+  @ApiResponses({
+    @ApiResponse(responseCode = HttpStatusCode.OK, description = "환불 처리 성공"),
+    @ApiResponse(
+        responseCode = HttpStatusCode.BAD_REQUEST,
+        description = "잘못된 주문 상태 (PAID가 아닌 경우)",
+        content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+    @ApiResponse(
+        responseCode = HttpStatusCode.NOT_FOUND,
+        description = "존재하지 않는 주문",
+        content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+  })
+  public ResponseEntity<OrderResponse> refundOrder(@PathVariable Long id) {
+    return ResponseEntity.ok(OrderResponse.from(orderService.refundOrder(id)));
+  }
 }

--- a/api/src/main/java/com/haeni/carrot/settle/order/OrderScheduler.java
+++ b/api/src/main/java/com/haeni/carrot/settle/order/OrderScheduler.java
@@ -1,0 +1,36 @@
+package com.haeni.carrot.settle.order;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderScheduler {
+
+  private final OrderService orderService;
+
+  @Scheduled(cron = "0 0 2 * * *")
+  public void autoConfirmExpiredOrders() {
+    LocalDateTime threshold = LocalDateTime.now().minusDays(7);
+    List<Long> orderIds = orderService.findPaidOrderIdsOlderThan(threshold);
+
+    log.info("자동 구매 확정 시작: 대상 {}건", orderIds.size());
+
+    int successCount = 0;
+    for (Long orderId : orderIds) {
+      try {
+        orderService.confirmOrder(orderId);
+        successCount++;
+      } catch (Exception e) {
+        log.error("자동 구매 확정 실패: orderId={}", orderId, e);
+      }
+    }
+
+    log.info("자동 구매 확정 완료: 성공 {}건 / 전체 {}건", successCount, orderIds.size());
+  }
+}

--- a/api/src/main/java/com/haeni/carrot/settle/order/OrderService.java
+++ b/api/src/main/java/com/haeni/carrot/settle/order/OrderService.java
@@ -4,6 +4,7 @@ import com.haeni.carrot.settle.common.exception.BusinessException;
 import com.haeni.carrot.settle.common.exception.ErrorCode;
 import com.haeni.carrot.settle.domain.order.Order;
 import com.haeni.carrot.settle.domain.order.OrderItem;
+import com.haeni.carrot.settle.domain.order.OrderStatus;
 import com.haeni.carrot.settle.domain.product.Product;
 import com.haeni.carrot.settle.domain.seller.Seller;
 import com.haeni.carrot.settle.domain.settlement.Settlement;
@@ -16,6 +17,7 @@ import com.haeni.carrot.settle.order.dto.OrderResponseDto;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -60,6 +62,27 @@ public class OrderService {
     }
 
     return OrderResponseDto.from(orderRepository.save(order));
+  }
+
+  public List<Long> findPaidOrderIdsOlderThan(LocalDateTime threshold) {
+    return orderRepository.findIdsByStatusAndCreatedAtBefore(OrderStatus.PAID, threshold);
+  }
+
+  @Transactional
+  public OrderResponseDto refundOrder(Long orderId) {
+    Order order =
+        orderRepository
+            .findByIdWithItems(orderId)
+            .orElseThrow(
+                () -> new BusinessException(ErrorCode.ORDER_NOT_FOUND, HttpStatus.NOT_FOUND));
+
+    try {
+      order.refund();
+    } catch (IllegalStateException e) {
+      throw new BusinessException(ErrorCode.INVALID_ORDER_STATUS, HttpStatus.BAD_REQUEST);
+    }
+
+    return OrderResponseDto.from(order);
   }
 
   @Transactional

--- a/api/src/test/java/com/haeni/carrot/settle/order/OrderServiceTest.java
+++ b/api/src/test/java/com/haeni/carrot/settle/order/OrderServiceTest.java
@@ -22,6 +22,7 @@ import com.haeni.carrot.settle.order.dto.CreateOrderRequest;
 import com.haeni.carrot.settle.order.dto.OrderItemRequest;
 import com.haeni.carrot.settle.order.dto.OrderResponseDto;
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -222,5 +223,72 @@ class OrderServiceTest {
     // when & then — CONFIRMED → CONFIRMED 전이는 불가
     assertThatThrownBy(() -> orderService.confirmOrder(1L))
         .isInstanceOf(BusinessException.class);
+  }
+
+  // ===================== refundOrder =====================
+
+  @Test
+  @DisplayName("PAID 상태 주문 환불 시 REFUNDED 상태로 변경된다")
+  void refundOrder_성공() {
+    // given
+    Seller seller = new Seller("셀러A", "seller@test.com", SellerGrade.STANDARD);
+    Product product = new Product(seller, "상품A", BigDecimal.valueOf(10000), 100);
+
+    Order order = new Order(BigDecimal.valueOf(10000));
+    order.addOrderItem(new OrderItem(order, product, 1, BigDecimal.valueOf(10000)));
+
+    given(orderRepository.findByIdWithItems(1L)).willReturn(Optional.of(order));
+
+    // when
+    OrderResponseDto response = orderService.refundOrder(1L);
+
+    // then
+    assertThat(response.status()).isEqualTo(OrderStatus.REFUNDED);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 주문 환불 시 BusinessException이 발생한다")
+  void refundOrder_존재하지않는주문_예외() {
+    // given
+    given(orderRepository.findByIdWithItems(999L)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> orderService.refundOrder(999L))
+        .isInstanceOf(BusinessException.class);
+  }
+
+  @Test
+  @DisplayName("CONFIRMED 상태 주문 환불 시 BusinessException이 발생한다")
+  void refundOrder_확정된주문_예외() {
+    // given
+    Seller seller = new Seller("셀러A", "seller@test.com", SellerGrade.STANDARD);
+    Product product = new Product(seller, "상품A", BigDecimal.valueOf(10000), 100);
+
+    Order order = new Order(BigDecimal.valueOf(10000));
+    order.addOrderItem(new OrderItem(order, product, 1, BigDecimal.valueOf(10000)));
+    order.confirm(); // PAID → CONFIRMED
+
+    given(orderRepository.findByIdWithItems(1L)).willReturn(Optional.of(order));
+
+    // when & then — CONFIRMED → REFUNDED 전이는 불가
+    assertThatThrownBy(() -> orderService.refundOrder(1L))
+        .isInstanceOf(BusinessException.class);
+  }
+
+  // ===================== findPaidOrderIdsOlderThan =====================
+
+  @Test
+  @DisplayName("7일 경과 PAID 주문 ID 목록을 반환한다")
+  void findPaidOrderIdsOlderThan_성공() {
+    // given
+    LocalDateTime threshold = LocalDateTime.now().minusDays(7);
+    given(orderRepository.findIdsByStatusAndCreatedAtBefore(OrderStatus.PAID, threshold))
+        .willReturn(List.of(1L, 2L, 3L));
+
+    // when
+    List<Long> result = orderService.findPaidOrderIdsOlderThan(threshold);
+
+    // then
+    assertThat(result).containsExactly(1L, 2L, 3L);
   }
 }

--- a/infrastructure/src/main/java/com/haeni/carrot/settle/infrastructure/order/OrderRepository.java
+++ b/infrastructure/src/main/java/com/haeni/carrot/settle/infrastructure/order/OrderRepository.java
@@ -1,6 +1,9 @@
 package com.haeni.carrot.settle.infrastructure.order;
 
 import com.haeni.carrot.settle.domain.order.Order;
+import com.haeni.carrot.settle.domain.order.OrderStatus;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -24,4 +27,9 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
           + " JOIN FETCH p.seller"
           + " WHERE o.id = :id")
   Optional<Order> findByIdWithItemsAndSeller(@Param("id") Long id);
+
+  /** 자동 구매 확정 대상: PAID 상태이고 생성일이 threshold 이전인 주문 ID 목록을 반환한다. */
+  @Query("SELECT o.id FROM Order o WHERE o.status = :status AND o.createdAt < :threshold")
+  List<Long> findIdsByStatusAndCreatedAtBefore(
+      @Param("status") OrderStatus status, @Param("threshold") LocalDateTime threshold);
 }


### PR DESCRIPTION
## 📝 변경사항

배송 완료 후 7일 경과 주문의 자동 구매 확정 스케줄러와 환불 API를 구현한다.

### 주요 변경사항
- `OrderScheduler` — `@Scheduled(cron = "0 0 2 * * *")` 자동 구매 확정, 빈 분리로 self-invocation 회피
- `PATCH /api/v1/orders/{id}/refund` — PAID → REFUNDED 상태 전이
- `OrderRepository` — 7일 경과 PAID 주문 ID 조회 쿼리 추가

### 상세 설명
- **self-invocation 해결**: `@Scheduled` 메서드를 `OrderScheduler` 빈으로 분리 → `orderService.confirmOrder(id)` 호출 시 Spring AOP 프록시 정상 동작. 같은 클래스 내 호출이었다면 `@Transactional`이 무시됨
- **건별 독립 트랜잭션**: 스케줄러가 각 주문 ID를 순회하며 `confirmOrder` 호출 → 1건 실패해도 나머지 처리 계속, 예외는 로그로 기록
- **환불 단순화**: PAID → REFUNDED 전이만 지원. Settlement는 CONFIRMED 시점에 생성되므로 PAID 상태 환불 시 정산 레코드 없음 — 별도 삭제 불필요

## 🔍 변경된 파일

```
OrderScheduler.java       — 신규, @Scheduled 자동 확정 빈
OrderService.java         — refundOrder(), findPaidOrderIdsOlderThan() 추가
OrderController.java      — PATCH /{id}/refund 엔드포인트 추가
OrderRepository.java      — findIdsByStatusAndCreatedAtBefore() 쿼리 추가
OrderServiceTest.java     — refundOrder 3종 + findPaidOrderIdsOlderThan 1종 테스트 추가
CLAUDE.md                 — API 테이블 및 스케줄러 패턴 업데이트
```

## 🧪 테스트

- [x] `./gradlew :api:test` 전체 테스트 통과
- [x] refundOrder 성공 / 존재하지않는주문\_예외 / 확정된주문\_예외
- [x] findPaidOrderIdsOlderThan 반환값 검증

### 테스트 방법
```bash
./gradlew :api:test --tests "com.haeni.carrot.settle.order.OrderServiceTest"
```

## ✅ 체크리스트

- [x] Conventional Commits 형식 준수
- [x] 민감 정보 미포함 확인
- [x] 관련 이슈 체크리스트 업데이트 완료

## 📚 관련 이슈

Closes #8