### PR TITLE
test: 수수료 계산 단위·통합 테스트 추가 (#11)

### DIFF
--- a/api/src/test/java/com/haeni/carrot/settle/fee/FeeCalculationServiceTest.java
+++ b/api/src/test/java/com/haeni/carrot/settle/fee/FeeCalculationServiceTest.java
@@ -9,6 +9,8 @@ import com.haeni.carrot.settle.domain.seller.SellerGrade;
 import java.math.BigDecimal;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 class FeeCalculationServiceTest {
 
@@ -52,5 +54,90 @@ class FeeCalculationServiceTest {
 
     // 999 * 0.03 = 29.97 → 30, 999 * 0.05 = 49.95 → 50, total = 80
     assertThat(fee.getTotalFee()).isEqualByComparingTo(fee.getPgFee().add(fee.getPlatformFee()));
+  }
+
+  @ParameterizedTest
+  @EnumSource(SellerGrade.class)
+  @DisplayName("0원 주문은 모든 등급에서 모든 수수료가 0원")
+  void calculate_0원_경계(SellerGrade grade) {
+    FeeDetail fee = service.calculate(BigDecimal.ZERO, grade);
+
+    assertThat(fee.getPgFee()).isEqualByComparingTo("0");
+    assertThat(fee.getPlatformFee()).isEqualByComparingTo("0");
+    assertThat(fee.getTotalFee()).isEqualByComparingTo("0");
+  }
+
+  @ParameterizedTest
+  @EnumSource(SellerGrade.class)
+  @DisplayName("1원 주문은 반올림으로 모든 수수료가 0원")
+  void calculate_1원_경계(SellerGrade grade) {
+    // 1 * 0.03 = 0.03 / 1 * 0.05 = 0.05 / 1 * 0.01 = 0.01 → 모두 HALF_UP → 0
+    FeeDetail fee = service.calculate(new BigDecimal("1"), grade);
+
+    assertThat(fee.getPgFee()).isEqualByComparingTo("0");
+    assertThat(fee.getPlatformFee()).isEqualByComparingTo("0");
+    assertThat(fee.getTotalFee()).isEqualByComparingTo("0");
+  }
+
+  @Test
+  @DisplayName("동일 입력 반복 호출 시 결과는 항상 같다 (멱등성)")
+  void calculate_멱등성() {
+    BigDecimal amount = new BigDecimal("12345");
+
+    FeeDetail first = service.calculate(amount, SellerGrade.STANDARD);
+    FeeDetail second = service.calculate(amount, SellerGrade.STANDARD);
+    FeeDetail third = service.calculate(amount, SellerGrade.STANDARD);
+
+    assertThat(first.getPgFee()).isEqualByComparingTo(second.getPgFee());
+    assertThat(first.getPgFee()).isEqualByComparingTo(third.getPgFee());
+    assertThat(first.getPlatformFee()).isEqualByComparingTo(second.getPlatformFee());
+    assertThat(first.getTotalFee()).isEqualByComparingTo(third.getTotalFee());
+  }
+
+  @Test
+  @DisplayName("반올림 경계가 없는 경우 단건 합산과 일괄 계산 결과가 일치한다")
+  void calculate_단건합산_vs_일괄계산_반올림없음() {
+    // 10000원 5건 vs 50000원 1건 — 각 계산이 정수로 떨어지는 케이스
+    BigDecimal single = new BigDecimal("10000");
+    int count = 5;
+    BigDecimal bulk = single.multiply(BigDecimal.valueOf(count));
+
+    BigDecimal pgSum = BigDecimal.ZERO;
+    BigDecimal platformSum = BigDecimal.ZERO;
+    for (int i = 0; i < count; i++) {
+      FeeDetail unit = service.calculate(single, SellerGrade.STANDARD);
+      pgSum = pgSum.add(unit.getPgFee());
+      platformSum = platformSum.add(unit.getPlatformFee());
+    }
+
+    FeeDetail bulkFee = service.calculate(bulk, SellerGrade.STANDARD);
+
+    assertThat(pgSum).isEqualByComparingTo(bulkFee.getPgFee());
+    assertThat(platformSum).isEqualByComparingTo(bulkFee.getPlatformFee());
+  }
+
+  @Test
+  @DisplayName("999원 10건 단건 합산과 9990원 일괄 계산 결과가 일치한다")
+  void calculate_단건합산_vs_일괄계산_반올림포함() {
+    // 단건: 999 * 0.03 = 29.97 → 30. 10건이면 300
+    // 일괄: 9990 * 0.03 = 299.7 → 300 → 일치
+    // 단건: 999 * 0.05 = 49.95 → 50. 10건이면 500
+    // 일괄: 9990 * 0.05 = 499.5 → 500 → 일치
+    BigDecimal single = new BigDecimal("999");
+    int count = 10;
+    BigDecimal bulk = single.multiply(BigDecimal.valueOf(count));
+
+    BigDecimal pgSum = BigDecimal.ZERO;
+    BigDecimal platformSum = BigDecimal.ZERO;
+    for (int i = 0; i < count; i++) {
+      FeeDetail unit = service.calculate(single, SellerGrade.STANDARD);
+      pgSum = pgSum.add(unit.getPgFee());
+      platformSum = platformSum.add(unit.getPlatformFee());
+    }
+
+    FeeDetail bulkFee = service.calculate(bulk, SellerGrade.STANDARD);
+
+    assertThat(pgSum).isEqualByComparingTo(bulkFee.getPgFee());
+    assertThat(platformSum).isEqualByComparingTo(bulkFee.getPlatformFee());
   }
 }

--- a/api/src/test/java/com/haeni/carrot/settle/order/OrderSettlementIntegrationTest.java
+++ b/api/src/test/java/com/haeni/carrot/settle/order/OrderSettlementIntegrationTest.java
@@ -1,0 +1,157 @@
+package com.haeni.carrot.settle.order;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.haeni.carrot.settle.TestcontainersConfiguration;
+import com.haeni.carrot.settle.domain.order.OrderStatus;
+import com.haeni.carrot.settle.domain.product.Product;
+import com.haeni.carrot.settle.domain.seller.SellerGrade;
+import com.haeni.carrot.settle.domain.settlement.Settlement;
+import com.haeni.carrot.settle.domain.settlement.SettlementStatus;
+import com.haeni.carrot.settle.infrastructure.product.ProductRepository;
+import com.haeni.carrot.settle.infrastructure.settlement.SettlementRepository;
+import com.haeni.carrot.settle.order.dto.CreateOrderRequest;
+import com.haeni.carrot.settle.order.dto.OrderItemRequest;
+import com.haeni.carrot.settle.order.dto.OrderResponseDto;
+import java.math.BigDecimal;
+import java.util.Comparator;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 주문 생성 → PAID → 구매 확정 → 수수료 계산 → Settlement 적재까지의 전체 흐름을 실제 DB(Testcontainers
+ * PostgreSQL)와 통합하여 검증한다.
+ */
+@SpringBootTest
+@Import(TestcontainersConfiguration.class)
+@Transactional
+class OrderSettlementIntegrationTest {
+
+  @Autowired private OrderService orderService;
+  @Autowired private ProductRepository productRepository;
+  @Autowired private SettlementRepository settlementRepository;
+
+  @Test
+  @DisplayName("단일 셀러 주문 생성 → 확정 시 Settlement에 FeeDetail이 정확히 적재된다")
+  void 주문생성_확정_수수료계산_통합() {
+    // given — V3 seed의 STANDARD 셀러(김철수) 상품 사용
+    Product product = findFirstProductByGrade(SellerGrade.STANDARD);
+    BigDecimal unitPrice = product.getPrice();
+    int quantity = 2;
+    BigDecimal expectedTotal = unitPrice.multiply(BigDecimal.valueOf(quantity));
+
+    // when — 주문 생성 (즉시 PAID)
+    OrderResponseDto created =
+        orderService.createOrder(
+            new CreateOrderRequest(List.of(new OrderItemRequest(product.getId(), quantity))));
+
+    assertThat(created.status()).isEqualTo(OrderStatus.PAID);
+    assertThat(created.totalAmount()).isEqualTo(expectedTotal.longValueExact());
+
+    // when — 구매 확정
+    OrderResponseDto confirmed = orderService.confirmOrder(created.id());
+    assertThat(confirmed.status()).isEqualTo(OrderStatus.CONFIRMED);
+
+    // then — Settlement 적재 검증
+    List<Settlement> settlements = settlementRepository.findAll();
+    assertThat(settlements).hasSize(1);
+
+    Settlement settlement = settlements.get(0);
+    assertThat(settlement.getStatus()).isEqualTo(SettlementStatus.INCOMPLETED);
+    assertThat(settlement.getSeller().getId()).isEqualTo(product.getSeller().getId());
+    assertThat(settlement.getTotalAmount()).isEqualByComparingTo(expectedTotal);
+
+    // STANDARD 셀러: PG 3% + 플랫폼 5% = 8%
+    BigDecimal expectedPgFee = expectedTotal.multiply(new BigDecimal("0.03")).setScale(0, java.math.RoundingMode.HALF_UP);
+    BigDecimal expectedPlatformFee = expectedTotal.multiply(new BigDecimal("0.05")).setScale(0, java.math.RoundingMode.HALF_UP);
+    BigDecimal expectedTotalFee = expectedPgFee.add(expectedPlatformFee);
+    BigDecimal expectedNetAmount = expectedTotal.subtract(expectedTotalFee);
+
+    assertThat(settlement.getFeeDetail().getPgFee()).isEqualByComparingTo(expectedPgFee);
+    assertThat(settlement.getFeeDetail().getPlatformFee()).isEqualByComparingTo(expectedPlatformFee);
+    assertThat(settlement.getFeeDetail().getTotalFee()).isEqualByComparingTo(expectedTotalFee);
+    assertThat(settlement.getNetAmount()).isEqualByComparingTo(expectedNetAmount);
+  }
+
+  @Test
+  @DisplayName("복수 셀러(STANDARD + VIP) 주문 확정 시 셀러별 Settlement가 각각 생성된다")
+  void 복수셀러_주문확정_셀러별_정산생성() {
+    // given — STANDARD 셀러 상품 + VIP 셀러 상품
+    Product standardProduct = findFirstProductByGrade(SellerGrade.STANDARD);
+    Product vipProduct = findFirstProductByGrade(SellerGrade.VIP);
+
+    // when — 두 셀러 상품을 섞어 주문
+    OrderResponseDto created =
+        orderService.createOrder(
+            new CreateOrderRequest(
+                List.of(
+                    new OrderItemRequest(standardProduct.getId(), 1),
+                    new OrderItemRequest(vipProduct.getId(), 1))));
+
+    orderService.confirmOrder(created.id());
+
+    // then — 셀러별로 Settlement 2건 생성
+    List<Settlement> settlements =
+        settlementRepository.findAll().stream()
+            .sorted(Comparator.comparing(s -> s.getSeller().getGrade()))
+            .toList();
+
+    assertThat(settlements).hasSize(2);
+
+    Settlement standardSettlement =
+        settlements.stream()
+            .filter(s -> s.getSeller().getGrade() == SellerGrade.STANDARD)
+            .findFirst()
+            .orElseThrow();
+    Settlement vipSettlement =
+        settlements.stream()
+            .filter(s -> s.getSeller().getGrade() == SellerGrade.VIP)
+            .findFirst()
+            .orElseThrow();
+
+    // STANDARD: 플랫폼 5%, VIP: 플랫폼 1%
+    assertThat(standardSettlement.getFeeDetail().getPlatformFee())
+        .isEqualByComparingTo(
+            standardProduct.getPrice().multiply(new BigDecimal("0.05")).setScale(0, java.math.RoundingMode.HALF_UP));
+    assertThat(vipSettlement.getFeeDetail().getPlatformFee())
+        .isEqualByComparingTo(
+            vipProduct.getPrice().multiply(new BigDecimal("0.01")).setScale(0, java.math.RoundingMode.HALF_UP));
+
+    // PG 수수료는 두 셀러 모두 3% 동일
+    assertThat(standardSettlement.getFeeDetail().getPgFee())
+        .isEqualByComparingTo(
+            standardProduct.getPrice().multiply(new BigDecimal("0.03")).setScale(0, java.math.RoundingMode.HALF_UP));
+    assertThat(vipSettlement.getFeeDetail().getPgFee())
+        .isEqualByComparingTo(
+            vipProduct.getPrice().multiply(new BigDecimal("0.03")).setScale(0, java.math.RoundingMode.HALF_UP));
+  }
+
+  @Test
+  @DisplayName("netAmount = totalAmount - totalFee 불변식이 실제 DB 적재 후에도 성립한다")
+  void netAmount_불변식_검증() {
+    Product product = findFirstProductByGrade(SellerGrade.PREMIUM);
+
+    OrderResponseDto created =
+        orderService.createOrder(
+            new CreateOrderRequest(List.of(new OrderItemRequest(product.getId(), 3))));
+    orderService.confirmOrder(created.id());
+
+    Settlement settlement = settlementRepository.findAll().get(0);
+
+    assertThat(settlement.getNetAmount())
+        .isEqualByComparingTo(
+            settlement.getTotalAmount().subtract(settlement.getFeeDetail().getTotalFee()));
+  }
+
+  private Product findFirstProductByGrade(SellerGrade grade) {
+    return productRepository.findAll().stream()
+        .filter(p -> p.getSeller().getGrade() == grade)
+        .findFirst()
+        .orElseThrow(() -> new IllegalStateException("V3 seed에 " + grade + " 셀러 상품이 없습니다"));
+  }
+}

--- a/domain/src/test/java/com/haeni/carrot/settle/domain/fee/PgFeeCalculatorTest.java
+++ b/domain/src/test/java/com/haeni/carrot/settle/domain/fee/PgFeeCalculatorTest.java
@@ -1,0 +1,55 @@
+package com.haeni.carrot.settle.domain.fee;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class PgFeeCalculatorTest {
+
+  private final PgFeeCalculator calculator = new PgFeeCalculator();
+
+  @Test
+  @DisplayName("10000원의 PG 수수료는 3% → 300원")
+  void calculate_기본() {
+    BigDecimal fee = calculator.calculate(new BigDecimal("10000"));
+    assertThat(fee).isEqualByComparingTo("300");
+  }
+
+  @ParameterizedTest(name = "{0}원 → PG 수수료 {1}원")
+  @CsvSource({
+    // 경계값: 0원, 1원은 반올림으로 0원
+    "0, 0",
+    "1, 0",
+    // 17원 * 0.03 = 0.51 → HALF_UP → 1원 (반올림 경계)
+    "17, 1",
+    // 16원 * 0.03 = 0.48 → HALF_UP → 0원
+    "16, 0",
+    // 999원 * 0.03 = 29.97 → 30원
+    "999, 30",
+    // 1000원 * 0.03 = 30원
+    "1000, 30",
+    // 100000원 * 0.03 = 3000원
+    "100000, 3000",
+    // 1234567원 * 0.03 = 37037.01 → 37037원
+    "1234567, 37037"
+  })
+  @DisplayName("PG 수수료는 금액 × 3% HALF_UP 반올림 결과와 일치한다")
+  void calculate_경계값(String amount, String expected) {
+    BigDecimal fee = calculator.calculate(new BigDecimal(amount));
+    assertThat(fee).isEqualByComparingTo(expected);
+  }
+
+  @Test
+  @DisplayName("동일 금액에 대한 반복 호출 결과는 항상 같다 (멱등성)")
+  void calculate_멱등성() {
+    BigDecimal amount = new BigDecimal("9999");
+    BigDecimal first = calculator.calculate(amount);
+    BigDecimal second = calculator.calculate(amount);
+    BigDecimal third = calculator.calculate(amount);
+    assertThat(first).isEqualByComparingTo(second).isEqualByComparingTo(third);
+  }
+}

--- a/domain/src/test/java/com/haeni/carrot/settle/domain/fee/PlatformFeeCalculatorTest.java
+++ b/domain/src/test/java/com/haeni/carrot/settle/domain/fee/PlatformFeeCalculatorTest.java
@@ -1,0 +1,81 @@
+package com.haeni.carrot.settle.domain.fee;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.haeni.carrot.settle.domain.seller.SellerGrade;
+import java.math.BigDecimal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class PlatformFeeCalculatorTest {
+
+  private final PlatformFeeCalculator calculator = new PlatformFeeCalculator();
+
+  @ParameterizedTest(name = "{0} 등급 10000원 → 플랫폼 수수료 {1}원")
+  @CsvSource({
+    "STANDARD, 500", // 10000 * 5%
+    "PREMIUM, 300", // 10000 * 3%
+    "VIP, 100" // 10000 * 1%
+  })
+  @DisplayName("등급별 요율이 올바르게 적용된다")
+  void calculate_등급별(SellerGrade grade, String expected) {
+    BigDecimal fee = calculator.calculate(new BigDecimal("10000"), grade);
+    assertThat(fee).isEqualByComparingTo(expected);
+  }
+
+  @ParameterizedTest(name = "{0}원 STANDARD → {1}원")
+  @CsvSource({
+    // STANDARD 5% 경계값
+    "0, 0",
+    "1, 0", // 0.05 → HALF_UP → 0
+    "10, 1", // 0.5 → HALF_UP → 1
+    "9, 0", // 0.45 → HALF_UP → 0
+    "999, 50", // 49.95 → 50
+    "10000, 500"
+  })
+  @DisplayName("STANDARD 등급 경계값: 금액 × 5% HALF_UP")
+  void calculate_STANDARD_경계값(String amount, String expected) {
+    BigDecimal fee = calculator.calculate(new BigDecimal(amount), SellerGrade.STANDARD);
+    assertThat(fee).isEqualByComparingTo(expected);
+  }
+
+  @ParameterizedTest(name = "{0}원 PREMIUM → {1}원")
+  @CsvSource({
+    "0, 0",
+    "1, 0", // 0.03 → 0
+    "17, 1", // 0.51 → 1
+    "16, 0", // 0.48 → 0
+    "999, 30", // 29.97 → 30
+    "10000, 300"
+  })
+  @DisplayName("PREMIUM 등급 경계값: 금액 × 3% HALF_UP")
+  void calculate_PREMIUM_경계값(String amount, String expected) {
+    BigDecimal fee = calculator.calculate(new BigDecimal(amount), SellerGrade.PREMIUM);
+    assertThat(fee).isEqualByComparingTo(expected);
+  }
+
+  @ParameterizedTest(name = "{0}원 VIP → {1}원")
+  @CsvSource({
+    "0, 0",
+    "1, 0", // 0.01 → 0
+    "50, 1", // 0.5 → 1
+    "49, 0", // 0.49 → 0
+    "999, 10", // 9.99 → 10
+    "10000, 100"
+  })
+  @DisplayName("VIP 등급 경계값: 금액 × 1% HALF_UP")
+  void calculate_VIP_경계값(String amount, String expected) {
+    BigDecimal fee = calculator.calculate(new BigDecimal(amount), SellerGrade.VIP);
+    assertThat(fee).isEqualByComparingTo(expected);
+  }
+
+  @ParameterizedTest
+  @EnumSource(SellerGrade.class)
+  @DisplayName("0원은 어떤 등급이든 플랫폼 수수료 0원")
+  void calculate_0원은_모든등급에서_0원(SellerGrade grade) {
+    BigDecimal fee = calculator.calculate(BigDecimal.ZERO, grade);
+    assertThat(fee).isEqualByComparingTo("0");
+  }
+}


### PR DESCRIPTION
## 📝 변경사항

이슈 #11 — 수수료 계산 Calculator 단위 테스트, `FeeCalculationService` 보강, 그리고 주문→구매확정→수수료 계산의 실제 DB 통합 테스트를 추가한다. 프로덕션 코드 변경은 없다.

### 주요 변경사항
- `PgFeeCalculatorTest` — 3% 고정율, HALF_UP 반올림 경계값(0/1/16/17/999/큰 금액), 멱등성
- `PlatformFeeCalculatorTest` — STANDARD 5% / PREMIUM 3% / VIP 1% 등급별 검증, 등급별 경계값, 전 등급에 대해 0원 입력은 0원 출력
- `FeeCalculationServiceTest` 보강 — 0원·1원 경계(모든 등급), 멱등성, **단건 합산 vs 일괄 계산 일치**(반올림 없는 케이스 + 포함 케이스 각 1건)
- `OrderSettlementIntegrationTest` (신규) — `@SpringBootTest + Testcontainers(PostgreSQL/Redis) + @Transactional` 기반 전체 흐름 통합 검증

### 상세 설명

**단위 테스트 전략**: `@ParameterizedTest` + `@CsvSource`/`@EnumSource`로 경계값을 선언적으로 나열. Calculator 로직(`amount × rate` HALF_UP)이 단순하므로 반올림 경계에 집중해 회귀 방지.

**단건 합산 vs 일괄 계산**: PRD 4.3 AC-2("단건 합산 == 일괄 계산")를 두 시나리오로 검증:
- 반올림이 발생하지 않는 케이스(10000원 × 5건) — 항상 수학적으로 일치
- 반올림이 발생하는 케이스(999원 × 10건 vs 9990원 일괄) — `29.97 → 30` × 10 = 300, `299.7 → 300`로 HALF_UP 하에서 우연히 일치함을 증명

**통합 테스트 설계**: V3 seed 데이터의 STANDARD/PREMIUM/VIP 셀러 상품을 활용해 실제 DB에 주문 저장 → `confirmOrder` 호출 → `settlementRepository.findAll()`로 Settlement 적재 검증. `@Transactional`로 테스트 간 격리 확보. 3 케이스:
1. 단일 셀러 주문 확정 시 FeeDetail 정확성
2. 복수 셀러(STANDARD + VIP) 주문 확정 시 셀러별 Settlement 분리
3. `netAmount = totalAmount - totalFee` 불변식이 DB 적재 후에도 성립

## 🔍 변경된 파일

```
 api/.../fee/FeeCalculationServiceTest.java            |  87 ++++++++ (보강)
 api/.../order/OrderSettlementIntegrationTest.java     | 157 +++++++++ (신규)
 domain/.../fee/PgFeeCalculatorTest.java               |  55 ++++++ (신규)
 domain/.../fee/PlatformFeeCalculatorTest.java         |  81 +++++++ (신규)
 4 files changed, 380 insertions(+)
```

## 🧪 테스트

- [x] `./gradlew test` 전체 테스트 통과 (domain 47 + api 35 = 82 cases)
- [x] `PgFeeCalculatorTest` / `PlatformFeeCalculatorTest` 단위 테스트 통과
- [x] `FeeCalculationServiceTest` 보강 케이스 포함 전체 통과
- [x] `OrderSettlementIntegrationTest` Testcontainers 기반 통합 테스트 통과

### 테스트 방법
```bash
./gradlew test
```

## ✅ 체크리스트

- [x] Conventional Commits 형식 준수 (`test:`)
- [x] 민감 정보 미포함 확인
- [x] 관련 이슈 체크리스트 업데이트 예정 (`/issue-done 11`)

## 📚 관련 이슈

Closes #11